### PR TITLE
[PRDI-602] Delete Pending Files On Network Failure

### DIFF
--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -30,6 +30,7 @@ public class Configuration {
         var autoAddSegmentDestination: Bool = true
         var apiHost: String = HTTPClient.getDefaultAPIHost()
         var cdnHost: String = HTTPClient.getDefaultCDNHost()
+        var maximumLogFilesOnDisk: Int = 15
     }
     internal var values: Values
 

--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -96,5 +96,11 @@ public extension Configuration {
         values.cdnHost = value
         return self
     }
+
+    @discardableResult
+    func maximumLogFilesOnDisk(_ value: Int) -> Configuration {
+        values.maximumLogFilesOnDisk = value
+        return self
+    }
 }
 

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -109,7 +109,20 @@ public class SegmentDestination: DestinationPlugin {
         guard let httpClient = self.httpClient else { return }
 
         // Read events from file system
-        guard let data = storage.read(Storage.Constants.events) else { return }
+        guard var data = storage.read(Storage.Constants.events) else { return }
+
+        let maximumLogFilesAllowed = analytics.configuration.values.maximumLogFilesOnDisk
+        // Check if we've exceeded the maximum allowed backlog of files and
+        // clean up the set of potential upload as needed.
+        if data.count > maximumLogFilesAllowed {
+            // The SDK Sorts the files with the newest ones being first, we'll
+            // keep these to try to forward on, but we'll drop anything older.
+            let filesToKeep = data.prefix(maximumLogFilesAllowed)
+            let filesToRemove = data.suffix(data.count - maximumLogFilesAllowed)
+            filesToRemove.forEach({ storage.remove(file: $0)})
+
+            data = Array(filesToKeep)
+        }
         
         eventCount = 0
         cleanupUploads()

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -119,7 +119,7 @@ public class SegmentDestination: DestinationPlugin {
             // keep these to try to forward on, but we'll drop anything older.
             let filesToKeep = data.prefix(maximumLogFilesAllowed)
             let filesToRemove = data.suffix(data.count - maximumLogFilesAllowed)
-            filesToRemove.forEach({ storage.remove(file: $0)})
+            filesToRemove.forEach({ storage.remove(file: $0) })
 
             data = Array(filesToKeep)
         }

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -125,15 +125,10 @@ public class SegmentDestination: DestinationPlugin {
                         case .success(_):
                             storage.remove(file: url)
                             self?.cleanupUploads()
-                        case let .failure(error):
-                            // Until https://github.com/segmentio/analytics-swift/issues/152 is resolved we should remove failing files since we run the risk of building up a huge list of pending files to upload.
-                            if error.connectivityError {
-                                storage.remove(file: url)
-                            }
+                        default:
+                            analytics.logFlush()
                     }
 
-                    analytics.logFlush()
-                    
                     analytics.log(message: "Processed: \(url.lastPathComponent)")
                     // the upload we have here has just finished.
                     // make sure it gets removed and it's cleanup() called rather

--- a/Sources/Segment/Utilities/HTTPClient.swift
+++ b/Sources/Segment/Utilities/HTTPClient.swift
@@ -16,23 +16,6 @@ enum HTTPClientErrors: Error {
     case statusCode(code: Int)
 }
 
-extension Error {
-    internal var connectivityError: Bool {
-        guard let urlError = self as? URLError else { return false }
-
-        switch urlError.code {
-        case .timedOut:
-            return true
-        case .notConnectedToInternet:
-            return true
-        case .networkConnectionLost:
-            return true
-        default:
-            return false
-        }
-    }
-}
-
 public class HTTPClient {
     private static let defaultAPIHost = "api.segment.io/v1"
     private static let defaultCDNHost = "cdn-settings.segment.com/v1"

--- a/Sources/Segment/Utilities/HTTPClient.swift
+++ b/Sources/Segment/Utilities/HTTPClient.swift
@@ -16,6 +16,23 @@ enum HTTPClientErrors: Error {
     case statusCode(code: Int)
 }
 
+extension Error {
+    internal var connectivityError: Bool {
+        guard let urlError = self as? URLError else { return false }
+
+        switch urlError.code {
+        case .timedOut:
+            return true
+        case .notConnectedToInternet:
+            return true
+        case .networkConnectionLost:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 public class HTTPClient {
     private static let defaultAPIHost = "api.segment.io/v1"
     private static let defaultCDNHost = "cdn-settings.segment.com/v1"


### PR DESCRIPTION
When members use a tool like Little Snitch or pi-hole to block outbound requests to segment.io, the Segment library will persist these analytics to disk into different files. These files can stack up immensely over time. This could mean you are trying to make 1,000s of network calls to upload these analytics that will never succeed. We would prefer to give this CPU time back to members at the trade off of maybe having some fewer events for the time being.

This means that as events fail to upload we will slowly delete the temporary files on disk so that they are not building up over time. This means that we will likely give up some analytics event integrity to give back CPU time and general performance to member machines that are in this state (i.e. people using this kind of blocking software).