### PR TITLE
Include device memory size in event context

### DIFF
--- a/Sources/Segment/Plugins/Context.swift
+++ b/Sources/Segment/Plugins/Context.swift
@@ -75,12 +75,14 @@ public class Context: PlatformPlugin {
     internal static func insertStaticPlatformContextData(context: inout [String: Any]) {
         // device
         let device = Self.device
+        let memoryGB = ProcessInfo.processInfo.physicalMemory / (1024*1024*1024)
         
         // "token" handled in DeviceToken.swift
         context["device"] = [
             "manufacturer": device.manufacturer,
             "type": device.type,
             "model": device.model,
+            "memorySize": memoryGB
         ]
         // os
         context["os"] = [


### PR DESCRIPTION
Includes the amount of physical memory on the computer in the `context` properties passed with every event we log through segment. This will let us segments users and all the data we collect by memory size in the same way we do for arm vs x86.

https://developer.apple.com/documentation/foundation/processinfo/1408211-physicalmemory

# Testing
<img width="864" alt="image" src="https://github.com/thebrowsercompany/analytics-swift/assets/1945488/d0dc169f-7cb5-4676-b05d-b89b71b071c4">
