### PR TITLE
Update protocol to not use framework specific types

### DIFF
--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -182,7 +182,7 @@ extension SegmentDestination {
             let before = uploads.count
             var newPending = uploads
             newPending.removeAll { uploadInfo in
-                let shouldRemove = uploadInfo.task.state != .running
+                let shouldRemove = !uploadInfo.task.isRunning()
                 if shouldRemove, let cleanup = uploadInfo.cleanup {
                     cleanup()
                 }

--- a/Sources/Segment/Utilities/Networking/HTTPSession+Apple.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPSession+Apple.swift
@@ -4,7 +4,11 @@ import Foundation
 import FoundationNetworking
 #endif
 
-extension URLSessionDataTask: DataTask {}
+extension URLSessionDataTask: DataTask {
+  public func isRunning() -> Bool {
+    state == .running
+  }
+}
 extension URLSessionUploadTask: UploadTask {}
 
 // Give the built in `URLSession` conformance to HTTPSession so that it can easily be used

--- a/Sources/Segment/Utilities/Networking/HTTPSession.swift
+++ b/Sources/Segment/Utilities/Networking/HTTPSession.swift
@@ -5,7 +5,7 @@ import FoundationNetworking
 #endif
 
 public protocol DataTask {
-  var state: URLSessionTask.State { get }
+  func isRunning() -> Bool
   func resume()
 }
 
@@ -31,3 +31,4 @@ public protocol HTTPSession {
   func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> DataTaskType
   func finishTasksAndInvalidate()
 }
+


### PR DESCRIPTION
Update the task protocol to not use framework-specific types since we might want to replace them in a different application. Opt instead for functions that represent the underlying data so that it's easier to mock and change the underlying implementation.