### PR TITLE
Removes application lifecycle event tracking

### DIFF
--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -16,7 +16,7 @@ public class Configuration {
     internal struct Values {
         var writeKey: String
         var application: Any? = nil
-        var trackApplicationLifecycleEvents: Bool = true
+        var trackApplicationLifecycleEvents: Bool = false
         var flushAt: Int = 20
         var flushInterval: TimeInterval = 30
         var defaultSettings: Settings? = nil

--- a/Tests/Segment-Tests/MemoryLeak_Tests.swift
+++ b/Tests/Segment-Tests/MemoryLeak_Tests.swift
@@ -19,7 +19,7 @@ final class MemoryLeak_Tests: XCTestCase {
     }
 
     func testLeaksVerbose() throws {
-        let analytics = Analytics(configuration: Configuration(writeKey: "1234"))
+        let analytics = Analytics(configuration: Configuration(writeKey: "1234").trackApplicationLifecycleEvents(true))
 
         waitUntilStarted(analytics: analytics)
         analytics.track(name: "test")

--- a/Tests/Segment-Tests/iOSLifecycle_Tests.swift
+++ b/Tests/Segment-Tests/iOSLifecycle_Tests.swift
@@ -5,7 +5,7 @@ import XCTest
 final class iOSLifecycle_Tests: XCTestCase {
     
     func testInstallEventCreation() {
-        let analytics = Analytics(configuration: Configuration(writeKey: "test"))
+        let analytics = Analytics(configuration: Configuration(writeKey: "test").trackApplicationLifecycleEvents(true))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
         
@@ -27,7 +27,7 @@ final class iOSLifecycle_Tests: XCTestCase {
     }
 
     func testInstallEventUpdated() {
-        let analytics = Analytics(configuration: Configuration(writeKey: "test"))
+        let analytics = Analytics(configuration: Configuration(writeKey: "test").trackApplicationLifecycleEvents(true))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
         
@@ -49,7 +49,7 @@ final class iOSLifecycle_Tests: XCTestCase {
     }
     
     func testInstallEventOpened() {
-        let analytics = Analytics(configuration: Configuration(writeKey: "test"))
+        let analytics = Analytics(configuration: Configuration(writeKey: "test").trackApplicationLifecycleEvents(true))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
         

--- a/Tests/Segment-Tests/iOSLifecycle_Tests.swift
+++ b/Tests/Segment-Tests/iOSLifecycle_Tests.swift
@@ -27,7 +27,7 @@ final class iOSLifecycle_Tests: XCTestCase {
     }
 
     func testInstallEventUpdated() {
-        let analytics = Analytics(configuration: Configuration(writeKey: "test").trackApplicationLifecycleEvents(enabled: true))
+        let analytics = Analytics(configuration: Configuration(writeKey: "test"))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
         

--- a/Tests/Segment-Tests/iOSLifecycle_Tests.swift
+++ b/Tests/Segment-Tests/iOSLifecycle_Tests.swift
@@ -27,7 +27,7 @@ final class iOSLifecycle_Tests: XCTestCase {
     }
 
     func testInstallEventUpdated() {
-        let analytics = Analytics(configuration: Configuration(writeKey: "test"))
+        let analytics = Analytics(configuration: Configuration(writeKey: "test").trackApplicationLifecycleEvents(enabled: true))
         let outputReader = OutputReaderPlugin()
         analytics.add(plugin: outputReader)
         


### PR DESCRIPTION
# Overview
The goal of this PR is to remove event tracking for application lifecycle events. 

# Notes
- These events have very high volume (particularly application backgrounded, opened, and foregrounded) and aren't currently used in any analyses.