### PR TITLE
Add configuration option for blind usage

### DIFF
--- a/Sources/Segment/Analytics.swift
+++ b/Sources/Segment/Analytics.swift
@@ -64,7 +64,9 @@ public class Analytics {
 
         // provide our default state
         store.provide(state: System.defaultState(configuration: configuration, from: storage))
-        store.provide(state: UserInfo.defaultState(from: storage))
+        if !configuration.values.blind {
+            store.provide(state: UserInfo.defaultState(from: storage))
+        }
 
         storage.analytics = self
 

--- a/Sources/Segment/Configuration.swift
+++ b/Sources/Segment/Configuration.swift
@@ -28,6 +28,7 @@ public class Configuration {
         var flushPolicies: [FlushPolicy] = [CountBasedFlushPolicy(), IntervalBasedFlushPolicy()]
         var maximumLogFilesOnDisk: Int = 15
         var httpSession: (() -> any HTTPSession)? = nil
+        var blind: Bool = false
     }
 
     internal var values: Values
@@ -82,6 +83,17 @@ public extension Configuration {
     @discardableResult
     func flushAt(_ count: Int) -> Configuration {
         values.flushAt = count
+        return self
+    }
+
+    /// Opt-in/out of blind mode. In blind mode, user identifier are stripped
+    /// from tracked events.
+    ///
+    /// - Parameter blind: Whether blind mode is enabled
+    /// - Returns: The current Configuration.
+    @discardableResult
+    func blind(_ enabled: Bool) -> Configuration {
+        values.blind = enabled
         return self
     }
 

--- a/Sources/Segment/Types.swift
+++ b/Sources/Segment/Types.swift
@@ -292,10 +292,10 @@ extension RawEvent {
     internal func applyRawEventData(store: Store) -> Self {
         var result: Self = self
         
-        guard let userInfo: UserInfo = store.currentState() else { return self }
+        let userInfo: UserInfo? = store.currentState()
         
-        result.anonymousId = userInfo.anonymousId
-        result.userId = userInfo.userId
+        result.anonymousId = userInfo?.anonymousId
+        result.userId = userInfo?.userId
         result.messageId = UUID().uuidString
         result.timestamp = Date().iso8601()
         result.integrations = try? JSON([String: Any]())


### PR DESCRIPTION
Contributes to AIQ-1711

Adding a `blind` property to the Analytics configuration.  When set to true, the values of the `annonymousId` and `userId` analytics event properties will not be reported to Segment.