### PR TITLE
Set the anonymous_id field to "redacted" when in blind mode

### DIFF
--- a/Sources/Segment/Types.swift
+++ b/Sources/Segment/Types.swift
@@ -294,7 +294,7 @@ extension RawEvent {
         
         let userInfo: UserInfo? = store.currentState()
         
-        result.anonymousId = userInfo?.anonymousId
+        result.anonymousId = userInfo?.anonymousId ?? "redacted"
         result.userId = userInfo?.userId
         result.messageId = UUID().uuidString
         result.timestamp = Date().iso8601()


### PR DESCRIPTION
The Segment backend requires the anonymousID field to be set.  Setting it to "redacted" when using Segment in "blind" mode.