### PR TITLE
fix: compare default apiHost with apiHost configuration instead of writeKey

### DIFF
--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -80,7 +80,7 @@ public class SegmentDestination: DestinationPlugin, Subscriber {
          */
         // if customer specifies a different apiHost (ie: eu1.segmentapis.com) at app.segment.com ...
         if let host = segmentInfo?[Self.Constants.apiHost.rawValue] as? String, host.isEmpty == false {
-            if host != analytics.configuration.values.writeKey {
+            if host != analytics.configuration.values.apiHost {
                 analytics.configuration.values.apiHost = host
                 httpClient = HTTPClient(analytics: analytics)
             }


### PR DESCRIPTION
Fix from https://github.com/segmentio/analytics-swift/pull/314. Unblocks using a proxy URL for Segment in Dia client